### PR TITLE
Correcting some grammar mistakes

### DIFF
--- a/profiles/base/skeleton/grails-app/i18n/messages_pt_BR.properties
+++ b/profiles/base/skeleton/grails-app/i18n/messages_pt_BR.properties
@@ -8,7 +8,7 @@ default.invalid.creditCard.message=O campo [{0}] da classe [{1}] com o valor [{2
 default.invalid.email.message=O campo [{0}] da classe [{1}] com o valor [{2}] não é um endereço de email válido.
 default.invalid.range.message=O campo [{0}] da classe [{1}] com o valor [{2}] não está entre a faixa de valores válida de [{3}] até [{4}]
 default.invalid.size.message=O campo [{0}] da classe [{1}] com o valor [{2}] não está na faixa de tamanho válida de [{3}] até [{4}]
-default.invalid.max.message=O campo [{0}] da classe [{1}] com o valor [{2}] ultrapass o valor máximo [{3}]
+default.invalid.max.message=O campo [{0}] da classe [{1}] com o valor [{2}] ultrapassa o valor máximo [{3}]
 default.invalid.min.message=O campo [{0}] da classe [{1}] com o valor [{2}] não atinge o valor mínimo [{3}]
 default.invalid.max.size.message=O campo [{0}] da classe [{1}] com o valor [{2}] ultrapassa o tamanho máximo de [{3}]
 default.invalid.min.size.message=O campo [{0}] da classe [{1}] com o valor [{2}] não atinge o tamanho mínimo de [{3}]
@@ -16,7 +16,7 @@ default.invalid.validator.message=O campo [{0}] da classe [{1}] com o valor [{2}
 default.not.inlist.message=O campo [{0}] da classe [{1}] com o valor [{2}] não é um valor dentre os permitidos na lista [{3}]
 default.blank.message=O campo [{0}] da classe [{1}] não pode ficar em branco
 default.not.equal.message=O campo [{0}] da classe [{1}] com o valor [{2}] não pode ser igual a [{3}]
-default.null.message=O campo [{0}] da classe [{1}] não pode ser vazia
+default.null.message=O campo [{0}] da classe [{1}] não pode ser vazio
 default.not.unique.message=O campo [{0}] da classe [{1}] com o valor [{2}] deve ser único
 
 default.paginate.prev=Anterior
@@ -30,7 +30,7 @@ default.created.message={0} {1} criado
 default.updated.message={0} {1} atualizado
 default.deleted.message={0} {1} removido
 default.not.deleted.message={0} {1} não pode ser removido
-default.not.found.message={0} não foi encontrado com id {1}
+default.not.found.message={0} não foi encontrado com o id {1}
 default.optimistic.locking.failure=Outro usuário atualizou este [{0}] enquanto você tentou salvá-lo
 
 default.home.label=Principal


### PR DESCRIPTION
1 - The word is ultrapassa and not ultrapass
2 - "Campo" is a "male" word, so we need to finish the sentence with vazio(for male empty objects) and not vazia(for female empty objects)
3 - default.not.found.message needs an article to define the id property.