### PR TITLE
Fix grails-core issue #9018 - Unable to create SSL cert w/ jdk8

### DIFF
--- a/profiles/base/commands/run-app.groovy
+++ b/profiles/base/commands/run-app.groovy
@@ -22,7 +22,7 @@ try {
     commandLine.systemProperties.each { key, value ->
         arguments << "-D${key}=$value".toString()
     }
-    
+
     if(port) {
         arguments << "-Dgrails.server.port=$port"
     }
@@ -43,9 +43,9 @@ try {
                     console.updateStatus "Generated SSL certificate"
                 }
                 else {
-                    console.warn "Unable to automatically generate SSL certificate, manual configuration required. Set 'server.ssl.key-store' in application.yml"   
+                    console.warn "Unable to automatically generate SSL certificate, manual configuration required. Set 'server.ssl.key-store' in application.yml"
                 }
-                
+
             }
             else {
                 keyStoreParametersAvailable = true
@@ -100,7 +100,7 @@ protected boolean createSSLCertificate(File keystoreDir) {
         catch(Throwable e) {
             return false
         }
-        
+
         return true
     }
     else {
@@ -110,17 +110,18 @@ protected boolean createSSLCertificate(File keystoreDir) {
 
 protected Class getKeyToolClass() {
     try {
+        // Sun JDK 8
+        return Class.forName( 'sun.security.tools.keytool.Main' )
+    }
+    catch(ClassNotFoundException e1) {
         try {
+            // Sun pre-JDK 8
             return Class.forName( 'sun.security.tools.KeyTool' )
         }
-        catch (ClassNotFoundException e) {
+        catch (ClassNotFoundException e2) {
             // no try/catch for this one, if neither is found let it fail
             return Class.forName( 'com.ibm.crypto.tools.KeyTool' )
         }
-        
     }
-    catch(Throwable e) {
-        return null
-    }
-    
+
 }

--- a/profiles/base/commands/run-app.groovy
+++ b/profiles/base/commands/run-app.groovy
@@ -110,18 +110,23 @@ protected boolean createSSLCertificate(File keystoreDir) {
 
 protected Class getKeyToolClass() {
     try {
-        // Sun JDK 8
-        return Class.forName( 'sun.security.tools.keytool.Main' )
-    }
-    catch(ClassNotFoundException e1) {
         try {
-            // Sun pre-JDK 8
-            return Class.forName( 'sun.security.tools.KeyTool' )
+            // Sun JDK 8
+            return Class.forName( 'sun.security.tools.keytool.Main' )
         }
-        catch (ClassNotFoundException e2) {
-            // no try/catch for this one, if neither is found let it fail
-            return Class.forName( 'com.ibm.crypto.tools.KeyTool' )
+        catch(ClassNotFoundException e1) {
+            try {
+                // Sun pre-JDK 8
+                return Class.forName( 'sun.security.tools.KeyTool' )
+            }
+            catch (ClassNotFoundException e2) {
+                // no try/catch for this one, if neither is found let it fail
+                return Class.forName( 'com.ibm.crypto.tools.KeyTool' )
+            }
         }
+    }
+    catch(Throwable e) {
+        return null
     }
 
 }


### PR DESCRIPTION
Fix for https://github.com/grails/grails-core/issues/9018 - Grails 3 w/ jdk8 (in Windows) can't create SSL cert

Works in Grails 2.5.x (jdk8 in Windows); And also works w/ Grails 3 (jdk7 in Windows).
 
Graeme pointed me to Grails 2.5.x code, https://github.com/grails-plugins/grails-tomcat-plugin/blob/master/src/groovy/org/grails/plugins/tomcat/TomcatServer.groovy#L208 , which I copied to 3.x

I didn't test it - not sure how.  It would be nice if this project was a gradle project, for testing, etc

Allen