### PR TITLE
Update create-taglib.yml

### DIFF
--- a/profiles/web/commands/create-taglib.yml
+++ b/profiles/web/commands/create-taglib.yml
@@ -1,6 +1,7 @@
 description:
     - Creates a Tag Library
     - usage: 'create-taglib [taglib name]'
+    - synonyms: 'create-tag-lib'
     - completer: org.grails.cli.interactive.completers.DomainClassCompleter
     - argument: Tag Library Name
       description: The name of the tag library


### PR DESCRIPTION
Add synonym for equivalent command in Grails 2.x and to match documented command.
I am not sure if it is valid syntax to have synonyms in YAML, as it is in the Gradle DSL.