### PR TITLE
Use unique endpoint jmx names

### DIFF
--- a/profiles/web/skeleton/grails-app/conf/application.yml
+++ b/profiles/web/skeleton/grails-app/conf/application.yml
@@ -57,6 +57,10 @@ hibernate:
         use_query_cache: false
         region.factory_class: 'org.hibernate.cache.ehcache.EhCacheRegionFactory' 
         
+endpoints:
+    jmx:
+        unique-names: true
+
 dataSource:
     pooled: true
     jmxExport: true


### PR DESCRIPTION
Enables deploying multiple grails applications into same container (e.g. Apache Tomcat)