### PR TITLE
Default to no userOrg in bintray config

### DIFF
--- a/profiles/plugin/templates/bintrayPublishing.gradle
+++ b/profiles/plugin/templates/bintrayPublishing.gradle
@@ -6,7 +6,7 @@ bintray {
     pkg {
         repo = project.hasProperty('repo') ? project.repo : 'plugins'
         userOrg = project.hasProperty('userOrg') ? project.userOrg : ''
-        name = "org.grails.plugins:$project.name"
+        name = "$project.group:$project.name"
         desc = project.hasProperty('desc') ? project.desc : "Grails $project.name plugin"
         websiteUrl = project.hasProperty('websiteUrl') ? project.websiteUrl : "http://grails.org/plugin/$project.name"
         issueTrackerUrl = project.hasProperty('issueTrackerUrl') ? project.issueTrackerUrl : "https://github.com/grails3-plugins/$project.name/issues"
@@ -14,7 +14,7 @@ bintray {
         licenses = project.hasProperty('license') ? [project.license] : ['Apache-2.0']
         publicDownloadNumbers = true
         version {
-            attributes = ['grails-plugin': "org.grails.plugins:$project.name"]
+            attributes = ['grails-plugin': "$project.group:$project.name"]
             name = project.version
             gpg {
                 sign = false

--- a/profiles/plugin/templates/bintrayPublishing.gradle
+++ b/profiles/plugin/templates/bintrayPublishing.gradle
@@ -5,7 +5,7 @@ bintray {
     publish = true
     pkg {
         repo = project.hasProperty('repo') ? project.repo : 'plugins'
-        userOrg = project.hasProperty('userOrg') ? project.userOrg : 'grails'
+        userOrg = project.hasProperty('userOrg') ? project.userOrg : ''
         name = "org.grails.plugins:$project.name"
         desc = project.hasProperty('desc') ? project.desc : "Grails $project.name plugin"
         websiteUrl = project.hasProperty('websiteUrl') ? project.websiteUrl : "http://grails.org/plugin/$project.name"


### PR DESCRIPTION
With the current default (userOrg = 'grails') all user contributed plugins will need to reset userOrg back to empty string or get an error when running bintrayUpload due to missing permission ("Could not create version '1.0.0.RC3': HTTP/1.1 403 Forbidden [message:forbidden]")