### PR TITLE
 Default to no userOrg in bintray config

### DIFF
--- a/profiles/plugin/templates/bintrayPublishing.gradle
+++ b/profiles/plugin/templates/bintrayPublishing.gradle
@@ -5,7 +5,7 @@ bintray {
     publish = true
     pkg {
         repo = project.hasProperty('repo') ? project.repo : 'plugins'
-        userOrg = project.hasProperty('userOrg') ? project.userOrg : 'grails'
+        userOrg = project.hasProperty('userOrg') ? project.userOrg : ''
         name = "$project.group:$project.name"
         desc = project.hasProperty('desc') ? project.desc : "Grails $project.name plugin"
         websiteUrl = project.hasProperty('websiteUrl') ? project.websiteUrl : "http://grails.org/plugin/$project.name"


### PR DESCRIPTION
With the current default (userOrg = 'grails') all user contributed plugins will need to reset userOrg back to empty string or get an error when running bintrayUpload due to missing permission ("Could not create version '1.0.0.RC3': HTTP/1.1 403 Forbidden [message:forbidden]")