### PR TITLE
Add a default typeMismatch message which is used for Boolean and primitive types

### DIFF
--- a/profiles/base/skeleton/grails-app/i18n/messages.properties
+++ b/profiles/base/skeleton/grails-app/i18n/messages.properties
@@ -53,3 +53,4 @@ typeMismatch.java.lang.Long=Property {0} must be a valid number
 typeMismatch.java.lang.Short=Property {0} must be a valid number
 typeMismatch.java.math.BigDecimal=Property {0} must be a valid number
 typeMismatch.java.math.BigInteger=Property {0} must be a valid number
+typeMismatch=Property {0} is type-mismatched


### PR DESCRIPTION
This was already merged to master branch (#27, d4f050c), but it should also be merged to 3.0.x.