### PR TITLE
Fix a configuration of grails.spring.transactionManagement".proxies" in application.yml

### DIFF
--- a/profiles/base/skeleton/grails-app/conf/application.yml
+++ b/profiles/base/skeleton/grails-app/conf/application.yml
@@ -3,7 +3,8 @@ grails:
     codegen:
         defaultPackage: @grails.codegen.defaultPackage@
     spring:
-        transactionManagement: false
+        transactionManagement:
+            proxies: false
 info:
     app:
         name: '@info.app.name@'


### PR DESCRIPTION
I think the right default configuration is `grails.spring.transactionManagement.proxies: false`, but currently `.proxies` is missing.

* http://grails.github.io/grails-doc/3.1.x/guide/upgrading.html#upgrading3x
* https://github.com/grails/grails-core/blob/master/grails-core/src/main/groovy/grails/config/Settings.groovy#L31