### PR TITLE
Use the ui.boostrap.collapse directive with the main navbar

### DIFF
--- a/profiles/angular/skeleton/grails-app/assets/javascripts/@grails.codegen.defaultPackage.path@/index/@grails.codegen.defaultPackage@.index.js
+++ b/profiles/angular/skeleton/grails-app/assets/javascripts/@grails.codegen.defaultPackage.path@/index/@grails.codegen.defaultPackage@.index.js
@@ -6,4 +6,8 @@
 //= require_tree templates
 //= require /angular/ui-bootstrap-tpls
 
-angular.module("@grails.codegen.defaultPackage@.index", ["@grails.codegen.defaultPackage@.core", 'ui.bootstrap.dropdown']);
+angular.module("@grails.codegen.defaultPackage@.index", [
+  "@grails.codegen.defaultPackage@.core",
+  "ui.bootstrap.dropdown",
+  "ui.bootstrap.collapse",
+]);

--- a/profiles/angular/skeleton/grails-app/views/index.gsp
+++ b/profiles/angular/skeleton/grails-app/views/index.gsp
@@ -26,7 +26,7 @@
     <div class="navbar navbar-default navbar-static-top" role="navigation">
         <div class="container">
             <div class="navbar-header">
-                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                <button type="button" class="navbar-toggle" ng-click="navExpanded = !navExpanded">
                     <span class="sr-only">Toggle navigation</span>
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
@@ -38,7 +38,7 @@
                     </i> Grails
                 </a>
             </div>
-            <div class="navbar-collapse collapse" aria-expanded="false" style="height: 0.8px;">
+            <div class="navbar-collapse collapse" aria-expanded="false" style="height: 0.8px;" uib-collapse="!navExpanded">
                 <ul class="nav navbar-nav navbar-right">
                     <li class="dropdown" uib-dropdown>
                         <a href="#" class="dropdown-toggle" uib-dropdown-toggle role="button" aria-haspopup="true" aria-expanded="false">Application Status <span class="caret"></span></a>


### PR DESCRIPTION
This PR removes the use of the standard bootstrap.js collapse functionality and replaces it with the `ui.bootstrap.collapse` directive. ([original pr](https://github.com/grails/grails-profile-repository/pull/57))