### PR TITLE
updating plugin profile to do a cleaner plugin packaging of assets

### DIFF
--- a/profiles/plugin/profile.yml
+++ b/profiles/plugin/profile.yml
@@ -1,11 +1,14 @@
 description: Profile for plugins designed to work across all profiles
 build:
     plugins:
+        - asset-pipeline
         - org.grails.grails-plugin
         - org.grails.grails-plugin-publish
     excludes:
         - org.grails.grails-core
 dependencies:
+    build:
+        - 'com.bertramlabs.plugins:asset-pipeline-gradle:2.8.1'
     provided:
         - "org.grails:grails-plugin-services"
         - "org.grails:grails-plugin-domain-class"

--- a/profiles/plugin/skeleton/build.gradle
+++ b/profiles/plugin/skeleton/build.gradle
@@ -12,3 +12,7 @@ grailsPublish {
     portalUser = ""
     portalPassword = ""    
 }
+
+assets {
+    packagePlugin=true
+}


### PR DESCRIPTION
This relates to PR grails/grails-core#9895 . Asset-pipeline gradle now handles packaging assets properly into `META-INF/assets` as well as generats a `META-INF/assets.list` file for recursive tree scanning on the classpath yay!