### PR TITLE
Correction for Hibernate configuration

### DIFF
--- a/profiles/base/features/hibernate/skeleton/grails-app/conf/application.yml
+++ b/profiles/base/features/hibernate/skeleton/grails-app/conf/application.yml
@@ -1,9 +1,10 @@
-hibernate:
-    cache:
-        queries: false
-        use_second_level_cache: true
-        use_query_cache: false
-        region.factory_class: 'org.hibernate.cache.ehcache.EhCacheRegionFactory'
+grails:
+    hibernate:
+        cache:
+            queries: false
+            use_second_level_cache: true
+            use_query_cache: false
+            region.factory_class: 'org.hibernate.cache.ehcache.EhCacheRegionFactory'
 
 dataSource:
     pooled: true


### PR DESCRIPTION
According to [this piece of code](https://github.com/grails/grails-data-mapping/blob/master/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/AbstractHibernateDatastore.java#L62) from [grails-data-mapping repository](https://github.com/grails/grails-data-mapping), the configuration for Hibernate is expected to be inside `grails` mapping, not at the root of the configuration file. So for example, to turn on/off query caching one would need to change `grails.hibernate.cache.queries` config property rather than `hibernate.cache.queries` as it is now.